### PR TITLE
feat: improve logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,34 +21,33 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
-var (
-	logger             = slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	GCP_TOKEN_AUDIENCE = "gcp"
+const (
+	gcpTokenAudience = "gcp"
+	stsRegionDefault = "us-east-1"
 )
 
+var logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
 // Creates GCP metadata client
-func gcpMetadataClient() *metadata.Client {
-	c := metadata.NewClient(&http.Client{Timeout: 1 * time.Second})
-	return c
+func newGCPMetadataClient() *metadata.Client {
+	return metadata.NewClient(&http.Client{Timeout: 1 * time.Second})
 }
 
-// Constucts AWs session identifier from GCP metadata infrmation.
-// This implementation uses concentration of  GCP project ID and machine hostname
+// Constructs AWS session identifier from GCP metadata information.
+// This implementation uses concatenation of GCP project ID and machine hostname.
 func createSessionIdentifier(c *metadata.Client) (string, error) {
 	ctx := context.Background()
 	projectId, err := c.ProjectIDWithContext(ctx)
 	if err != nil {
-		logger.Error("Couldn't fetch ProjectId from GCP metadata server")
-		return "", err
+		return "", fmt.Errorf("couldn't fetch ProjectId from GCP metadata server: %w", err)
 	}
 
 	hostname, err := c.HostnameWithContext(ctx)
 	if err != nil {
-		logger.Error("Couldn't fetch Hostname from GCP metadata server")
-		return "", err
+		return "", fmt.Errorf("couldn't fetch Hostname from GCP metadata server: %w", err)
 	}
 
-	return (fmt.Sprintf("%s-%s", projectId, hostname)[:32]), nil
+	return fmt.Sprintf("%s-%s", projectId, hostname)[:32], nil
 }
 
 // gcpTokenSource returns an OAuth2 token source for authenticating with GCP GKE.
@@ -56,14 +55,12 @@ func createSessionIdentifier(c *metadata.Client) (string, error) {
 func gcpTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 	credentials, err := google.FindDefaultCredentials(ctx)
 	if err != nil {
-		logger.Debug("Couldn't fetch GCP default credentials from environment")
-		return nil, err
+		return nil, fmt.Errorf("couldn't fetch GCP default credentials from environment: %w", err)
 	}
 
-	ts, err := idtoken.NewTokenSource(ctx, GCP_TOKEN_AUDIENCE, option.WithCredentials(credentials))
+	ts, err := idtoken.NewTokenSource(ctx, gcpTokenAudience, option.WithCredentials(credentials))
 	if err != nil {
-		logger.Debug("Couldn't fetch GCP identity token")
-		return nil, err
+		return nil, fmt.Errorf("couldn't fetch GCP identity token: %w", err)
 	}
 	return ts, nil
 }
@@ -75,7 +72,7 @@ type customIdentityTokenRetriever struct {
 func (obj customIdentityTokenRetriever) GetIdentityToken() ([]byte, error) {
 	token, err := obj.tokenSource.Token()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't retrieve identity token: %w", err)
 	}
 	return []byte(token.AccessToken), nil
 }
@@ -88,14 +85,14 @@ type awsTempCredentials struct {
 	Expiration      time.Time `json:"Expiration"`
 }
 
-// Custom stringer for awsCredentials stuct
+// Custom stringer for awsTempCredentials struct
 func (c awsTempCredentials) String() string {
-	return fmt.Sprintf("{\"Version\": %d, \"AccessKeyId\": \"%s\", \"SecretAccessKey\": \"%s\", \"SessionToken\": \"%s\", \"Expiration\": \"%s\"}", 1, c.AccessKeyId, c.SecretAccessKey, c.SessionToken, c.Expiration.Format("2006-01-02T15:04:05-07:00"))
+	return fmt.Sprintf("{\"Version\": %d, \"AccessKeyId\": \"%s\", \"SecretAccessKey\": \"%s\", \"SessionToken\": \"%s\", \"Expiration\": \"%s\"}", 1, c.AccessKeyId, c.SecretAccessKey, c.SessionToken, c.Expiration.Format(time.RFC3339))
 }
 
 func main() {
 	awsAssumeRoleArn := flag.String("rolearn", "", "AWS role ARN to assume (required)")
-	stsRegion := flag.String("stsregion", "us-east-1", "AWS STS region to which requests are made (optional)")
+	stsRegion := flag.String("stsregion", stsRegionDefault, "AWS STS region to which requests are made (optional)")
 
 	flag.Parse()
 	if *awsAssumeRoleArn == "" {
@@ -105,27 +102,27 @@ func main() {
 
 	ctx := context.Background()
 
-	gcpMetadataClient := gcpMetadataClient()
+	gcpMetadataClient := newGCPMetadataClient()
 	if gcpMetadataClient == nil {
-		logger.Error("Expected non-nil metadata client, got nil")
+		logger.Error("expected non-nil metadata client, got nil")
 		os.Exit(1)
 	}
 
 	sessionIdentifier, err := createSessionIdentifier(gcpMetadataClient)
 	if err != nil {
-		logger.Error("Failed to create session identifier from GCP metadata, %s" + err.Error())
+		logger.Error(fmt.Sprintf("failed to create session identifier from GCP metadata: %v", err))
 		os.Exit(1)
 	}
 
 	assumeRoleCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(*stsRegion))
 	if err != nil {
-		logger.Error("failed to load default AWS config, %s" + err.Error())
+		logger.Error(fmt.Sprintf("failed to load default AWS config: %v", err))
 		os.Exit(1)
 	}
 
 	gcpMetadataTokenSource, err := gcpTokenSource(ctx)
 	if err != nil {
-		logger.Error("Failed to get JWT token from GCP metadata, %s" + err.Error())
+		logger.Error(fmt.Sprintf("failed to get JWT token from GCP metadata: %v", err))
 		os.Exit(1)
 	}
 
@@ -143,7 +140,7 @@ func main() {
 
 	awsCredentials, err := awsCredsCache.Retrieve(ctx)
 	if err != nil {
-		logger.Error(fmt.Sprintf("Couldn't retrieve AWS credentials %s", err))
+		logger.Error(fmt.Sprintf("couldn't retrieve AWS credentials: %v", err))
 		os.Exit(1)
 	}
 
@@ -152,7 +149,8 @@ func main() {
 		AccessKeyId:     awsCredentials.AccessKeyID,
 		SecretAccessKey: awsCredentials.SecretAccessKey,
 		SessionToken:    awsCredentials.SessionToken,
-		Expiration:      awsCredentials.Expires}
+		Expiration:      awsCredentials.Expires,
+	}
 
 	fmt.Printf("%+v\n", credentials)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -85,7 +85,10 @@ func TestCreateSessionIdentifier(t *testing.T) {
 	}
 	defer f.Shutdown()
 
-	sessionID, err := createSessionIdentifier(gcpMetadataClient())
+	// Create a GCP metadata client
+	client := newGCPMetadataClient()
+
+	sessionID, err := createSessionIdentifier(client)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -112,7 +115,9 @@ func TestGCEMatadataDataHostname(t *testing.T) {
 	}
 	defer f.Shutdown()
 
-	client := gcpMetadataClient()
+	// Create a GCP metadata client
+	client := newGCPMetadataClient()
+
 	if client == nil {
 		t.Errorf("Expected non-nil metadata client, got nil")
 	}
@@ -139,7 +144,9 @@ func TestGCEMatadataDataProjectID(t *testing.T) {
 	}
 	defer f.Shutdown()
 
-	client := gcpMetadataClient()
+	// Create a GCP metadata client
+	client := newGCPMetadataClient()
+
 	if client == nil {
 		t.Errorf("Expected non-nil metadata client, got nil")
 	}


### PR DESCRIPTION
This pull request includes several changes to the `main.go` and `main_test.go` files to improve code readability, error handling, and consistency. The most important changes include converting variables to constants, improving error messages, and renaming functions for clarity.

Improvements to code readability and consistency:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L24-R63): Converted `GCP_TOKEN_AUDIENCE` to a constant `gcpTokenAudience` and introduced a new constant `stsRegionDefault`.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L24-R63): Renamed `gcpMetadataClient` to `newGCPMetadataClient` to better reflect its purpose. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L24-R63) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L108-R125)

Enhancements to error handling:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L24-R63): Improved error messages by using `fmt.Errorf` to include more context. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L24-R63) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L78-R75) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L146-R143)
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L108-R125): Updated logger error messages to be more consistent in format and content. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L108-R125) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L146-R143)

Test updates:

* [`main_test.go`](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL88-R91): Updated tests to use the new `newGCPMetadataClient` function. [[1]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL88-R91) [[2]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL115-R120) [[3]](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL142-R149)