### PR TITLE
Trigger release on create release workflow creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,10 @@
 name: Release
 
 on:
-  release:
-    types: [created]
+  workflow_run:
+    workflows: ["Create Release"]
+    types:
+      - completed
 
 permissions:
     contents: write


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/release.yaml` file to change the trigger for the release workflow. The most important change is the modification of the event that triggers the workflow from a `release` event to a `workflow_run` event.

Workflow trigger update:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL4-R7): Changed the trigger for the release workflow from `release` event to `workflow_run` event, specifying that it should run after the "Create Release" workflow completes.