### PR TITLE
Trigger release worklflow on release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [created]
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file `.github/workflows/create-release.yaml`. The change adds a new trigger for the workflow to run when a release is created.

* [`.github/workflows/create-release.yaml`](diffhunk://#diff-a318819fb0ec8889018cbef8e6dd222e317757d95ddd93b62b714ac7c49f04f6R7-R8): Added a `release` trigger to run the workflow when a release is created.