### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project was inspired by [Janus](https://github.com/doitintl/janus), a pytho
 Download appropriate release for your OS and achitecture from the project's release page.
 
 ```bash
-wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.2.8/janus-v0.2.8-linux-amd64 && chmod +x janus-go
+wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.3.0/janus-v0.3.0-linux-amd64 && chmod +x janus-go
 ```
 ### Inside Kubernetes pod
 To use the binary inside of Kubernetes pod, download the binary using init container and mount the binary path inside of your main container:
@@ -30,7 +30,7 @@ spec:
      image: alpine:3
      command: [sh, -c]
      args:
-       - wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.2.8/janus-v0.2.8-linux-amd64 && chmod +x janus-go && mv janus-go /janus-go/
+       - wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.3.0/janus-v0.3.0-linux-amd64 && chmod +x janus-go && mv janus-go /janus-go/
      volumeMounts:
        - mountPath: /janus-go
          name: janus-go


### PR DESCRIPTION
This pull request updates the version of the `janus-go` binary used in the project. The changes ensure that the latest version of the binary is being downloaded and used in both the standalone and Kubernetes pod setups.

Version update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16): Updated the download URL for the `janus-go` binary from version `v0.2.8` to `v0.3.0` in the standalone setup instructions.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33): Updated the download URL for the `janus-go` binary from version `v0.2.8` to `v0.3.0` in the Kubernetes pod setup instructions.