### PR TITLE
Centralize and improve logging and add param to print ID token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
 # Janus-go
+
 ![E2E GCP](https://github.com/zepellin/janus-go/actions/workflows/e2e-gcp.yaml/badge.svg)
+![E2E SA KEY](https://github.com/zepellin/janus-go/actions/workflows/e2e-sa-key.yaml/badge.svg)
+
 ## Description
+
 Janus-go is a AWS CLI external source authentication program for use with Google Cloud GKE workload identity or GCE VM identity. It is designed to allow authenticating AWS IAM role from Google Cloud environments (such as GKE cluster or GCE VM instance) without the need of generating long term AWS credentials.
 
 This project was inspired by [Janus](https://github.com/doitintl/janus), a python implementation of the same authentication flow. This project was written in go for easier installation and usage of the program where a single binary is implementation is better suited (such as inside of existing container running on kubernetes).
 
 ## Prerequisites
+
 1. The environment in which the program is running has to be able to provide Google Cloud Identity token from Google Cloud metadata server. This can be achieved either by running on GCE VM instance or as a GKE workload with workload identity enabled
-2. An AWS IAM role is created with a [trust policy specifying the Google Cloud IAM identity](https://aws.amazon.com/blogs/security/access-aws-using-a-google-cloud-platform-native-workload-identity/) used by VM instance or GKE workload identity from step 1. 
+2. An AWS IAM role is created with a [trust policy specifying the Google Cloud IAM identity](https://aws.amazon.com/blogs/security/access-aws-using-a-google-cloud-platform-native-workload-identity/) used by VM instance or GKE workload identity from step 1.
+
 ## Installation
+
 ### Locally
+
 Download appropriate release for your OS and achitecture from the project's release page.
 
 ```bash
-wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.3.0/janus-v0.3.0-linux-amd64 && chmod +x janus-go
+wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.4.2/janus-v0.4.2-linux-amd64 && chmod +x janus-go
 ```
-### Inside Kubernetes pod
+
+### Inside of a Kubernetes pod
+
 To use the binary inside of Kubernetes pod, download the binary using init container and mount the binary path inside of your main container:
 
-```
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -30,7 +40,7 @@ spec:
      image: alpine:3
      command: [sh, -c]
      args:
-       - wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.3.0/janus-v0.3.0-linux-amd64 && chmod +x janus-go && mv janus-go /janus-go/
+       - wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.4.2/janus-v0.4.2-linux-amd64 && chmod +x janus-go && mv janus-go /janus-go/
      volumeMounts:
        - mountPath: /janus-go
          name: janus-go
@@ -46,19 +56,24 @@ spec:
    - name: janus-go
      emptyDir: {}
 ```
+
 ## Usage
+
 Assuming pre-requisites for running the application have been met and AWS SDK configuration file in a following format exists:
 
-```
+```text
 [profile my-aws-account]
 credential_process = /usr/local/bin/janus-go -rolearn arn:aws:iam::123456789012:role/my-trusted-role
 ```
+
 AWS clients such as AWS CLI or [AWS Terraform provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) can now authenticate agains specified AWS profile and use AWS APIs.
 
-```
+```bash
 aws --profile my-aws-account ec2 describe-instances
 ```
+
 ## Contributing
+
 To contribute to Janus-go, follow these steps:
 
 1. Fork the repository.
@@ -69,5 +84,5 @@ To contribute to Janus-go, follow these steps:
 6. Create a new Pull Request.
 
 ## License
-This project uses the following license: [MIT](LICENSE).
 
+This project uses the following license: [MIT](LICENSE).

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,33 @@
+package logger
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Logger is the global logger instance that can be used across packages
+var Logger *slog.Logger
+
+// InitLogger initializes the global logger with the specified level
+func InitLogger(level string) {
+	logLevel := parseLogLevel(level)
+	Logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+}
+
+func parseLogLevel(level string) slog.Level {
+	switch strings.ToUpper(level) {
+	case "DEBUG":
+		return slog.LevelDebug
+	case "INFO":
+		return slog.LevelInfo
+	case "WARN":
+		return slog.LevelWarn
+	case "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,22 +4,24 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log/slog"
 	"os"
 
 	"janus/aws"
 	"janus/gcp"
+	"janus/logger"
 	"janus/types"
 )
-
-var logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
 func main() {
 	awsAssumeRoleArn := flag.String("rolearn", "", "AWS role ARN to assume (required)")
 	stsRegion := flag.String("stsregion", types.STSRegionDefault, "AWS STS region to which requests are made (optional)")
 	sessionId := flag.String("sessionid", "", "AWS session identifier (optional) (defaults AWS_SESSION_IDENTIFIER or GCP metadata)")
+	logLevel := flag.String("loglevel", "ERROR", "Logging level (DEBUG, INFO, WARN, ERROR)")
 
 	flag.Parse()
+
+	logger.InitLogger(*logLevel)
+
 	if *awsAssumeRoleArn == "" {
 		flag.Usage()
 		os.Exit(1)
@@ -29,25 +31,25 @@ func main() {
 
 	gcpMetadataClient := gcp.NewMetadataClient()
 	if gcpMetadataClient == nil {
-		logger.Error("Failed to create GCP metadata client: got nil")
+		logger.Logger.Error("Failed to create GCP metadata client: got nil")
 		os.Exit(1)
 	}
 
-	sessionIdentifier, err := aws.GetSessionIdentifier(*sessionId, gcpMetadataClient)
+	sessionIdentifier, err := gcp.GetSessionIdentifier(*sessionId, gcpMetadataClient)
 	if err != nil {
-		logger.Error(fmt.Errorf("failed to get session identifier: %w", err).Error())
+		logger.Logger.Error(fmt.Errorf("failed to get session identifier: %w", err).Error())
 		os.Exit(1)
 	}
 
 	// Ensure stsRegion isn't nil
 	if stsRegion == nil {
-		logger.Error("stsRegion is nil, cannot proceed")
+		logger.Logger.Error("stsRegion is nil, cannot proceed")
 		os.Exit(1)
 	}
 
 	gcpMetadataTokenSource, err := gcp.TokenSource(ctx)
 	if err != nil {
-		logger.Error(fmt.Errorf("failed to retrieve GCP identity token: %w", err).Error())
+		logger.Logger.Error(fmt.Errorf("failed to retrieve GCP identity token: %w", err).Error())
 		os.Exit(1)
 	}
 
@@ -55,7 +57,7 @@ func main() {
 
 	credentials, err := aws.GetCredentials(ctx, *stsRegion, *awsAssumeRoleArn, sessionIdentifier, gcpMetadataToken)
 	if err != nil {
-		logger.Error(err.Error())
+		logger.Logger.Error(err.Error())
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -14,11 +14,18 @@ import (
 
 func main() {
 	awsAssumeRoleArn := flag.String("rolearn", "", "AWS role ARN to assume (required)")
+	printIdToken := flag.Bool("printidtoken", false, "Print Google identity token when log level is DEBUG")
 	stsRegion := flag.String("stsregion", types.STSRegionDefault, "AWS STS region to which requests are made (optional)")
 	sessionId := flag.String("sessionid", "", "AWS session identifier (optional) (defaults AWS_SESSION_IDENTIFIER or GCP metadata)")
 	logLevel := flag.String("loglevel", "ERROR", "Logging level (DEBUG, INFO, WARN, ERROR)")
 
 	flag.Parse()
+
+	// Initialize global configuration
+	types.SetConfig(types.Config{
+		PrintIdToken: *printIdToken,
+		LogLevel:     *logLevel,
+	})
 
 	logger.InitLogger(*logLevel)
 
@@ -61,5 +68,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// AWS CLI config credential_process requires JSON output containing credentials
+	// and expiration time
 	fmt.Printf("%+v\n", credentials)
 }

--- a/types/config.go
+++ b/types/config.go
@@ -1,0 +1,21 @@
+package types
+
+// Config holds the global configuration settings
+type Config struct {
+	// PrintIdToken indicates whether to print the identity token when log level is DEBUG
+	PrintIdToken bool
+	// LogLevel specifies the logging level (DEBUG, INFO, WARN, ERROR)
+	LogLevel string
+}
+
+var globalConfig Config
+
+// SetConfig sets the global configuration
+func SetConfig(config Config) {
+	globalConfig = config
+}
+
+// GetConfig returns the global configuration
+func GetConfig() Config {
+	return globalConfig
+}


### PR DESCRIPTION
This pull request includes significant changes to the logging system and the handling of session identifiers. The most important changes include the introduction of a new logging package, refactoring of session identifier retrieval, and updates to the main application logic to use the new logging and configuration mechanisms.

### Logging System Enhancements:
* Introduced a new `logger` package with a global logger instance and initialization function (`logger/logger.go`).
* Replaced all instances of `slog` with the new `logger.Logger` across various files (`aws/credentials.go`, `gcp/metadata.go`, `main.go`). [[1]](diffhunk://#diff-34b64721b0cda9ac2cbe912049c7c5d1630a8300c5cc70db6e02dcd081517c58L6-L10) [[2]](diffhunk://#diff-a5b41480b99e24fdc2d051fa3e60bbdf08351857b6e2ef27d131aec9a7663035R13-R14) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L7-R31)

### Session Identifier Refactoring:
* Moved the `GetSessionIdentifier` function from `aws/credentials.go` to `gcp/metadata.go` and added logging for better traceability (`aws/credentials.go`, `gcp/metadata.go`). [[1]](diffhunk://#diff-34b64721b0cda9ac2cbe912049c7c5d1630a8300c5cc70db6e02dcd081517c58L20-R27) [[2]](diffhunk://#diff-a5b41480b99e24fdc2d051fa3e60bbdf08351857b6e2ef27d131aec9a7663035L41-R75)

### Main Application Logic Updates:
* Added new command-line flags for log level and identity token printing, and initialized the global logger and configuration in `main.go` (`main.go`). [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L7-R31) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L32-R72)

### Configuration Management:
* Introduced a new `types.Config` struct to hold global configuration settings and functions to set and get the configuration (`types/config.go`).

### Additional Logging:
* Added debug logging statements in the `GetCredentials` and `TokenSource` functions to provide more detailed runtime information (`aws/credentials.go`, `gcp/metadata.go`). [[1]](diffhunk://#diff-34b64721b0cda9ac2cbe912049c7c5d1630a8300c5cc70db6e02dcd081517c58R39-R45) [[2]](diffhunk://#diff-a5b41480b99e24fdc2d051fa3e60bbdf08351857b6e2ef27d131aec9a7663035L69-R122) [[3]](diffhunk://#diff-a5b41480b99e24fdc2d051fa3e60bbdf08351857b6e2ef27d131aec9a7663035L83-R135)