### PR TITLE
fix: Actions release date

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,5 +31,5 @@ jobs:
           -s -w
           -X janus/types.Version=${{ github.event.release.tag_name }}
           -X janus/types.Commit=${{ github.sha }}
-          -X janus/types.Date=$(date -u +%Y-%m-%d)
+          -X janus/types.Date=${{ github.event.release.created_at }}
         build_flags: "-trimpath"


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/release.yaml` file to improve the accuracy of the release date.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL34-R34): Modified the build flags to use the release creation date from the GitHub event instead of the current date.