### PR TITLE
Better context handling

### DIFF
--- a/gcp/metadata.go
+++ b/gcp/metadata.go
@@ -144,7 +144,7 @@ func GetSessionIdentifier(ctx context.Context, sessionIdFlag string, gcpMetadata
 // CreateSessionIdentifier constructs AWS session identifier from GCP metadata information.
 // This implementation uses concatenation of GCP project ID and machine hostname.
 func CreateSessionIdentifier(ctx context.Context, c *contextAwareMetadataClient) (string, error) {
-	projectId, err := c.ProjectIDWithContext(ctx)
+	projectID, err := c.ProjectIDWithContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("couldn't fetch ProjectID from GCP metadata server: %w", err)
 	}
@@ -154,7 +154,7 @@ func CreateSessionIdentifier(ctx context.Context, c *contextAwareMetadataClient)
 		return "", fmt.Errorf("couldn't fetch Hostname from GCP metadata server: %w", err)
 	}
 
-	return fmt.Sprintf("%s-%s", projectId, hostname)[:32], nil
+	return fmt.Sprintf("%s-%s", projectID, hostname)[:32], nil
 }
 
 // printIdentityTokenIfEnabled prints the identity token if enabled in config and log level is DEBUG

--- a/gcp/metadata.go
+++ b/gcp/metadata.go
@@ -146,7 +146,7 @@ func GetSessionIdentifier(ctx context.Context, sessionIdFlag string, gcpMetadata
 func CreateSessionIdentifier(ctx context.Context, c *contextAwareMetadataClient) (string, error) {
 	projectId, err := c.ProjectIDWithContext(ctx)
 	if err != nil {
-		return "", fmt.Errorf("couldn't fetch ProjectId from GCP metadata server: %w", err)
+		return "", fmt.Errorf("couldn't fetch ProjectID from GCP metadata server: %w", err)
 	}
 
 	hostname, err := c.HostnameWithContext(ctx)

--- a/main.go
+++ b/main.go
@@ -45,13 +45,13 @@ func main() {
 
 	ctx := context.Background()
 
-	gcpMetadataClient := gcp.NewMetadataClient()
+	gcpMetadataClient := gcp.NewMetadataClient(ctx)
 	if gcpMetadataClient == nil {
 		logger.Logger.Error("Failed to create GCP metadata client: got nil")
 		os.Exit(1)
 	}
 
-	sessionIdentifier, err := gcp.GetSessionIdentifier(*sessionId, gcpMetadataClient)
+	sessionIdentifier, err := gcp.GetSessionIdentifier(ctx, *sessionId, gcpMetadataClient)
 	if err != nil {
 		logger.Logger.Error(fmt.Errorf("failed to get session identifier: %w", err).Error())
 		os.Exit(1)

--- a/main_test.go
+++ b/main_test.go
@@ -88,7 +88,7 @@ func setupMockServer(t *testing.T) (*mds.MetadataServer, func()) {
 	}
 
 	// Give the server a moment to start up
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	return f, func() {
 		f.Shutdown()

--- a/main_test.go
+++ b/main_test.go
@@ -114,7 +114,7 @@ func TestCreateSessionIdentifier(t *testing.T) {
 	}
 }
 
-func TestGCEMatadataDataHostname(t *testing.T) {
+func TestGCEMetadataHostname(t *testing.T) {
 	_, cleanup := setupMockServer(t)
 	defer cleanup()
 
@@ -133,7 +133,7 @@ func TestGCEMatadataDataHostname(t *testing.T) {
 	assert.Equal(t, gceInstanceHostname, metadataHostname, "Retrieved hostname does not match expected value")
 }
 
-func TestGCEMatadataDataProjectID(t *testing.T) {
+func TestGCEMetadataProjectID(t *testing.T) {
 	_, cleanup := setupMockServer(t)
 	defer cleanup()
 


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of context in the GCP metadata client, enhances test coverage, and refactors some existing code for better maintainability. The most important changes include creating a context-aware GCP metadata client, updating related functions to use context, and adding new tests for context cancellation and timeout scenarios.

### Enhancements to GCP metadata client:

* Introduced a new `contextAwareMetadataClient` struct that extends the standard `metadata.Client` with context handling. This includes methods like `ProjectIDWithContext` and `HostnameWithContext` to respect context cancellation and timeout. (`gcp/metadata.go`, [gcp/metadata.goL41-R103](diffhunk://#diff-a5b41480b99e24fdc2d051fa3e60bbdf08351857b6e2ef27d131aec9a7663035L41-R103))
* Added a `contextTransport` type to wrap HTTP requests with context, ensuring that the context state is checked before making requests. (`gcp/metadata.go`, [gcp/metadata.goL41-R103](diffhunk://#diff-a5b41480b99e24fdc2d051fa3e60bbdf08351857b6e2ef27d131aec9a7663035L41-R103))

### Updates to existing functions:

* Modified `GetSessionIdentifier` and `CreateSessionIdentifier` to accept a context parameter and check context state before proceeding with operations. (`gcp/metadata.go`, [[1]](diffhunk://#diff-a5b41480b99e24fdc2d051fa3e60bbdf08351857b6e2ef27d131aec9a7663035L61-R131) [[2]](diffhunk://#diff-a5b41480b99e24fdc2d051fa3e60bbdf08351857b6e2ef27d131aec9a7663035L80-R146)
* Updated the `main` function to pass a context to the GCP metadata client and session identifier retrieval. (`main.go`, [main.goL48-R54](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L48-R54))

### Improvements to testing:

* Refactored test setup by introducing a `setupMockServer` helper function for creating and managing mock GCP metadata servers. (`main_test.go`, [main_test.goL73-R106](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eL73-R106))
* Added new tests to verify that operations respect context cancellation (`TestContextCancellation`) and context timeouts (`TestContextTimeout`). (`main_test.go`, [main_test.goR186-R251](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR186-R251))

### Miscellaneous changes:

* Removed the unused `time` package import from `gcp/metadata.go`. (`gcp/metadata.go`, [gcp/metadata.goL11](diffhunk://#diff-a5b41480b99e24fdc2d051fa3e60bbdf08351857b6e2ef27d131aec9a7663035L11))
* Initialized the logger in test files to ensure consistent error logging during tests. (`main_test.go`, [main_test.goR31-L33](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR31-L33))