### PR TITLE
Add/remove modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project was inspired by [Janus](https://github.com/doitintl/janus), a pytho
 Download appropriate release for your OS and achitecture from the project's release page.
 
 ```bash
-wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.4.2/janus-v0.4.2-linux-amd64 && chmod +x janus-go
+wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.4.5/janus-v0.4.5-linux-amd64 && chmod +x janus-go
 ```
 
 ### Inside of a Kubernetes pod
@@ -40,7 +40,7 @@ spec:
      image: alpine:3
      command: [sh, -c]
      args:
-       - wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.4.2/janus-v0.4.2-linux-amd64 && chmod +x janus-go && mv janus-go /janus-go/
+       - wget -qO janus-go https://github.com/zepellin/janus-go/releases/download/v0.4.5/janus-v0.4.5-linux-amd64 && chmod +x janus-go && mv janus-go /janus-go/
      volumeMounts:
        - mountPath: /janus-go
          name: janus-go

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/prometheus/procfs v0.16.0 h1:xh6oHhKwnOJKMYiYBDWmkHqQPyiY40sny36Cmx2b
 github.com/prometheus/procfs v0.16.0/go.mod h1:8veyXUu3nGP7oaCxhX6yeaM5u4stL2FeMXnCqhDthZg=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/salrashid123/gce_metadata_server v0.0.0-20250730160746-1626da5adcea h1:sPwLm4Rgn3u30GEeYKoALMyOlGoCmLbuNRsWMiaKri8=
-github.com/salrashid123/gce_metadata_server v0.0.0-20250730160746-1626da5adcea/go.mod h1:U4pEu8Ga9xPCsEkfl2eNId4CmM0AuSJ9IBNsZDWKeVk=
+github.com/salrashid123/gce_metadata_server v0.0.0-20250804201548-a9a9db1280e7 h1:NX216NCF9cnN5dKU/UJBK8GM9dkIFe277JLQaxVsyZc=
+github.com/salrashid123/gce_metadata_server v0.0.0-20250804201548-a9a9db1280e7/go.mod h1:U4pEu8Ga9xPCsEkfl2eNId4CmM0AuSJ9IBNsZDWKeVk=
 github.com/salrashid123/golang-jwt-tpm v1.8.92 h1:vy113IFgPG1fzGs8QqvBVl4k0dvEbAigd1OrSQXQk5o=
 github.com/salrashid123/golang-jwt-tpm v1.8.92/go.mod h1:VHtf9HQTgrlKPfQazUt8ey8DuqZoKpc1Y1WhPtM35FA=
 github.com/salrashid123/oauth2/v3 v3.0.4 h1:vntcacuybKqc/+UpjOifVnkwchFAB29IP9ig/hBHqKQ=


### PR DESCRIPTION
This pull request updates the version of the `janus-go` binary used in the documentation to reflect the latest release. The changes ensure that users download and use version `v0.4.5` instead of the outdated version `v0.4.2`.

### Documentation updates:

* Updated the `wget` command in the `README.md` to download `janus-go` version `v0.4.5` in the standalone installation instructions.
* Updated the `wget` command in the Kubernetes pod example in the `README.md` to use `janus-go` version `v0.4.5`.