### PR TITLE
Add renovate go mod tidy update option

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
   "extends": [
     "config:recommended"
   ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
   "timezone": "Europe/Madrid",
   "schedule": [
     "* 20-23 * * *"

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
-  ]
+  ],
   "timezone": "Europe/Madrid",
   "schedule": [
     "* 20-23 * * *"


### PR DESCRIPTION
This pull request makes a small configuration change to the `renovate.json` file. The change adds a post-update option to run `gomodTidy` after dependency updates, which helps keep Go module files clean and up-to-date.