### PR TITLE
fix: eliminate panic on short session IDs, stale region list, and context-in-struct

### DIFF
--- a/gcp/metadata.go
+++ b/gcp/metadata.go
@@ -40,30 +40,24 @@ type credentialsFile struct {
 	ClientEmail  string `json:"client_email"`
 }
 
-// contextAwareMetadataClient wraps the standard metadata.Client with better context handling
-type contextAwareMetadataClient struct {
+// MetadataClient wraps the standard metadata.Client
+type MetadataClient struct {
 	*metadata.Client
-	ctx context.Context
 }
 
-// NewMetadataClient creates a new GCP metadata client with context
-func NewMetadataClient(ctx context.Context) *contextAwareMetadataClient {
+// NewMetadataClient creates a new GCP metadata client
+func NewMetadataClient(_ context.Context) *MetadataClient {
 	baseClient := metadata.NewClient(&http.Client{
-		Transport: &contextTransport{
-			base: http.DefaultTransport,
-			ctx:  ctx,
-		},
 		Timeout: metadataClientTimeout,
 	})
 
-	return &contextAwareMetadataClient{
+	return &MetadataClient{
 		Client: baseClient,
-		ctx:    ctx,
 	}
 }
 
 // ProjectIDWithContext gets the project ID with context awareness
-func (c *contextAwareMetadataClient) ProjectIDWithContext(ctx context.Context) (string, error) {
+func (c *MetadataClient) ProjectIDWithContext(ctx context.Context) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
@@ -71,35 +65,16 @@ func (c *contextAwareMetadataClient) ProjectIDWithContext(ctx context.Context) (
 }
 
 // HostnameWithContext gets the hostname with context awareness
-func (c *contextAwareMetadataClient) HostnameWithContext(ctx context.Context) (string, error) {
+func (c *MetadataClient) HostnameWithContext(ctx context.Context) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
 	return c.Client.HostnameWithContext(ctx)
 }
 
-type contextTransport struct {
-	base http.RoundTripper
-	ctx  context.Context
-}
-
-func (t *contextTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Check context state before making the request
-	select {
-	case <-t.ctx.Done():
-		return nil, t.ctx.Err()
-	default:
-		// Context is still valid, proceed with the request
-	}
-
-	// Create a new request with our context
-	req = req.WithContext(t.ctx)
-	return t.base.RoundTrip(req)
-}
-
 // GetSessionIdentifier retrieves session identifier from command line flag, environment variable,
 // or generates it from GCP metadata (in that order of precedence)
-func GetSessionIdentifier(ctx context.Context, sessionIdFlag string, gcpMetadataClient *contextAwareMetadataClient) (string, error) {
+func GetSessionIdentifier(ctx context.Context, sessionIdFlag string, gcpMetadataClient *MetadataClient) (string, error) {
 	// First check context state
 	if err := ctx.Err(); err != nil {
 		return "", err
@@ -147,7 +122,7 @@ func GetSessionIdentifier(ctx context.Context, sessionIdFlag string, gcpMetadata
 
 // CreateSessionIdentifier constructs AWS session identifier from GCP metadata information.
 // This implementation uses concatenation of GCP project ID and machine hostname.
-func CreateSessionIdentifier(ctx context.Context, c *contextAwareMetadataClient) (string, error) {
+func CreateSessionIdentifier(ctx context.Context, c *MetadataClient) (string, error) {
 	projectID, err := c.ProjectIDWithContext(ctx)
 	if err != nil {
 		return "", fmt.Errorf("couldn't fetch ProjectID from GCP metadata server: %w", err)
@@ -158,7 +133,11 @@ func CreateSessionIdentifier(ctx context.Context, c *contextAwareMetadataClient)
 		return "", fmt.Errorf("couldn't fetch Hostname from GCP metadata server: %w", err)
 	}
 
-	return fmt.Sprintf("%s-%s", projectID, hostname)[:32], nil
+	s := fmt.Sprintf("%s-%s", projectID, hostname)
+	if len(s) > 32 {
+		s = s[:32]
+	}
+	return s, nil
 }
 
 // printIdentityTokenIfEnabled prints the identity token if enabled in config and log level is DEBUG

--- a/types/validation.go
+++ b/types/validation.go
@@ -10,62 +10,9 @@ import (
 // Also supports AWS partitions (aws, aws-cn, aws-us-gov)
 var arnPattern = regexp.MustCompile(`^arn:(aws|aws-cn|aws-us-gov):iam::\d{12}:role\/[a-zA-Z0-9+=,.@\-_/]+$`)
 
-// validAWSRegions contains all valid AWS regions as of November 2025
-// Source: https://docs.aws.amazon.com/general/latest/gr/rande.html
-var validAWSRegions = map[string]bool{
-	// US regions
-	"us-east-1": true, // US East (N. Virginia)
-	"us-east-2": true, // US East (Ohio)
-	"us-west-1": true, // US West (N. California)
-	"us-west-2": true, // US West (Oregon)
-
-	// Africa
-	"af-south-1": true, // Africa (Cape Town)
-
-	// Asia Pacific
-	"ap-east-1":      true, // Asia Pacific (Hong Kong)
-	"ap-south-1":     true, // Asia Pacific (Mumbai)
-	"ap-south-2":     true, // Asia Pacific (Hyderabad)
-	"ap-northeast-1": true, // Asia Pacific (Tokyo)
-	"ap-northeast-2": true, // Asia Pacific (Seoul)
-	"ap-northeast-3": true, // Asia Pacific (Osaka)
-	"ap-southeast-1": true, // Asia Pacific (Singapore)
-	"ap-southeast-2": true, // Asia Pacific (Sydney)
-	"ap-southeast-3": true, // Asia Pacific (Jakarta)
-	"ap-southeast-4": true, // Asia Pacific (Melbourne)
-
-	// Canada
-	"ca-central-1": true, // Canada (Central)
-	"ca-west-1":    true, // Canada West (Calgary)
-
-	// Europe
-	"eu-central-1": true, // Europe (Frankfurt)
-	"eu-central-2": true, // Europe (Zurich)
-	"eu-west-1":    true, // Europe (Ireland)
-	"eu-west-2":    true, // Europe (London)
-	"eu-west-3":    true, // Europe (Paris)
-	"eu-north-1":   true, // Europe (Stockholm)
-	"eu-south-1":   true, // Europe (Milan)
-	"eu-south-2":   true, // Europe (Spain)
-
-	// Middle East
-	"me-south-1":   true, // Middle East (Bahrain)
-	"me-central-1": true, // Middle East (UAE)
-
-	// South America
-	"sa-east-1": true, // South America (São Paulo)
-
-	// AWS GovCloud (US)
-	"us-gov-east-1": true, // AWS GovCloud (US-East)
-	"us-gov-west-1": true, // AWS GovCloud (US-West)
-
-	// China regions
-	"cn-north-1":     true, // China (Beijing)
-	"cn-northwest-1": true, // China (Ningxia)
-
-	// Israel
-	"il-central-1": true, // Israel (Tel Aviv)
-}
+// Matches standard AWS region format: {area}-{sub}-{number}
+// Covers commercial, GovCloud (us-gov-*), and China (cn-*) regions.
+var regionPattern = regexp.MustCompile(`^(us(-gov)?|af|ap|ca|eu|me|sa|cn|il)-(central|north|south|east|west|northeast|northwest|southeast|southwest)-\d$`)
 
 // ValidateRoleArn validates that the provided string is a valid AWS IAM role ARN
 func ValidateRoleArn(arn string) error {
@@ -86,10 +33,9 @@ func ValidateSTSRegion(region string) error {
 		return fmt.Errorf("STS region cannot be empty")
 	}
 
-	// Normalize to lowercase for comparison
 	normalizedRegion := strings.ToLower(strings.TrimSpace(region))
 
-	if !validAWSRegions[normalizedRegion] {
+	if !regionPattern.MatchString(normalizedRegion) {
 		return fmt.Errorf("invalid AWS region: %s (see https://docs.aws.amazon.com/general/latest/gr/rande.html for valid regions)", region)
 	}
 

--- a/types/validation_test.go
+++ b/types/validation_test.go
@@ -191,6 +191,12 @@ func TestValidateSTSRegion(t *testing.T) {
 			region:  "il-central-1",
 			wantErr: false,
 		},
+		// Future regions should be accepted without code changes
+		{
+			name:    "valid future region",
+			region:  "eu-south-3",
+			wantErr: false,
+		},
 		// Invalid cases
 		{
 			name:    "empty region",


### PR DESCRIPTION
## Summary

- **Panic fix** (`gcp/metadata.go`): `CreateSessionIdentifier` was unconditionally slicing the `projectID-hostname` string to 32 characters. If that string is shorter than 32 chars, this panics. Added a length guard before the slice.
- **Region validation** (`types/validation.go`): The hardcoded `validAWSRegions` map needed to be updated every time AWS launches a new region. Replaced it with a regex pattern matching the standard `{area}-{direction}-{digit}` format. New regions are accepted automatically, and a test case for a hypothetical future region (`eu-south-3`) documents this intent.
- **Context-in-struct removed** (`gcp/metadata.go`): `contextAwareMetadataClient` stored a `context.Context` in a struct field and used a custom `contextTransport` to inject it into every HTTP request. This is a Go anti-pattern — the stored context becomes stale. Removed the stored context and `contextTransport` entirely; context is now passed per-call only via the existing `WithContext` methods.

## Test plan

- [ ] All existing `TestValidateRoleArn` and `TestValidateSTSRegion` cases pass
- [ ] New `valid future region` test case passes
- [ ] `TestCreateSessionIdentifier`, `TestContextCancellation`, `TestContextTimeout` still pass with the refactored `MetadataClient`
- [ ] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)