### PR TITLE
Renovate: Update schedule and set min age for dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,9 @@
   ],
   "timezone": "Europe/Madrid",
   "schedule": [
-    "* 20-23 * * *"
+    "* 20-23 * * 0"
   ],
+  "minimumReleaseAge": "7 days",
   "rebaseWhen": "behind-base-branch",
   "separateMajorMinor": true,
   "separateMinorPatch": true,


### PR DESCRIPTION
This pull request updates the Renovate configuration to refine the scheduling and release management for dependency updates. The most important changes are:

Renovate scheduling:

* The `schedule` field has been updated to run Renovate only on Sundays between 20:00 and 23:59, instead of every day during those hours.

Release management:

* A new `minimumReleaseAge` field has been added, requiring updates to be at least 7 days old before being considered for merging.